### PR TITLE
chore: 피드백 표현과 정적 페이지 head 구성을 정리

### DIFF
--- a/backend/feedback_utils.py
+++ b/backend/feedback_utils.py
@@ -21,6 +21,28 @@ def format_ranked_counts(values: dict, *, suffix: str, limit: int = 4):
     return ', '.join(f'{name} {count}{suffix}' for name, count in ranked)
 
 
+POLITE_SENTENCE_ENDING_PATTERN = re.compile(
+    r'(?:니다|세요|해요|이에요|예요|군요|네요|까요|드려요|줘요|아요|어요)(?:[.!?…]+)?$'
+)
+
+
+def split_feedback_sentences(text: str):
+    parts = re.split(r'(?<=[.!?])\s+|\n+', text.strip())
+    return [
+        part.strip(" \t\r\n\"'`“”‘’()[]{}")
+        for part in parts
+        if part.strip()
+    ]
+
+
+def uses_consistent_polite_tone(text: str):
+    sentences = split_feedback_sentences(text)
+    if not sentences:
+        return False
+
+    return all(POLITE_SENTENCE_ENDING_PATTERN.search(sentence) for sentence in sentences)
+
+
 def build_feedback(
     summary: dict,
     top_language: str | None,
@@ -160,6 +182,9 @@ def sanitize_feedback(payload: dict):
         or len(cleaned_feedback['next_step']) < 18
     ):
         return None, 'too_short'
+
+    if not all(uses_consistent_polite_tone(value) for value in cleaned_feedback.values()):
+        return None, 'non_polite_tone'
 
     return cleaned_feedback, 'ok'
 
@@ -396,18 +421,21 @@ def build_ai_prompt(
 - 톤: {style_notes['tone']}
 - headline: {style_notes['headline_rule']}
 - strength: {style_notes['strength_rule']}
+- 공통 말투: 모든 문장은 일관된 존댓말로만 작성한다.
 
 [작성 규칙]
 1. 자연스러운 한국어만 사용한다.
-2. 초보 개발자, 활동을 시작하셨군요, 仓库 같은 어색한 표현은 금지한다.
-3. 숫자를 기계적으로 나열하지 말고 흐름과 맥락을 먼저 설명한다.
-4. headline, strength, improvement, next_step는 서로 다른 문장으로 작성한다.
-5. strength 또는 improvement 중 최소 하나에는 실제 근거를 1개 이상 자연스럽게 녹여라. 예: Push 18회, 활동 일수 11일, PR 기록이 적다.
-6. improvement는 보완 포인트, next_step는 바로 실행할 제안에 집중한다.
-7. next_step에서 막연히 push를 늘리라고만 말하지 말고 구체 행동을 제안한다.
-8. 아래처럼 너무 안전하고 비슷한 문장은 피한다: "흐름이 보입니다", "조금 더 보완하면 좋습니다", "기록을 남겨보세요"만 반복하는 식의 문장.
-9. 서비스 문구처럼 짧고 또렷하게 쓰되, 계정별 차이가 느껴지게 작성한다.
-10. JSON 외 텍스트는 출력하지 않는다.
+2. 모든 문장은 존댓말로만 작성하고, 반말이나 해체, 서술형 "-다" 말투는 금지한다.
+3. 문장 끝은 "~습니다", "~보입니다", "~좋습니다", "~해보세요"처럼 공손한 표현으로 마무리한다.
+4. 초보 개발자, 활동을 시작하셨군요, 仓库 같은 어색한 표현은 금지한다.
+5. 숫자를 기계적으로 나열하지 말고 흐름과 맥락을 먼저 설명한다.
+6. headline, strength, improvement, next_step는 서로 다른 문장으로 작성한다.
+7. strength 또는 improvement 중 최소 하나에는 실제 근거를 1개 이상 자연스럽게 녹여라. 예: Push 18회, 활동 일수 11일, PR 기록이 적다.
+8. improvement는 보완 포인트, next_step는 바로 실행할 제안에 집중한다.
+9. next_step에서 막연히 push를 늘리라고만 말하지 말고 구체 행동을 제안한다.
+10. 아래처럼 너무 안전하고 비슷한 문장은 피한다: "흐름이 보입니다", "조금 더 보완하면 좋습니다", "기록을 남겨보세요"만 반복하는 식의 문장.
+11. 서비스 문구처럼 짧고 또렷하게 쓰되, 계정별 차이가 느껴지게 작성한다.
+12. JSON 외 텍스트는 출력하지 않는다.
 
 [응답 JSON 형식]
 {{

--- a/backend/main.py
+++ b/backend/main.py
@@ -23,6 +23,7 @@ from feedback_utils import (
     build_strength_hints,
     format_ranked_counts,
     normalize_feedback,
+    uses_consistent_polite_tone,
     window_label,
 )
 
@@ -32,8 +33,8 @@ GITHUB_TIME_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
 ALLOWED_WINDOWS = {7, 30, 90, 180, 365}
 MAX_GITHUB_EVENT_PAGES = 3
 EVENT_API_RELIABLE_WINDOW_DAYS = 90
-FEEDBACK_PROMPT_VERSION = 'v2'
-COMPARISON_PROMPT_VERSION = 'v1'
+FEEDBACK_PROMPT_VERSION = 'v3'
+COMPARISON_PROMPT_VERSION = 'v2'
 
 # 실행 위치와 관계없이 루트 또는 backend 폴더의 .env를 읽습니다.
 load_dotenv(PROJECT_ROOT / '.env')
@@ -212,7 +213,10 @@ def generate_feedback_with_groq(
             messages=[
                 {
                     'role': 'system',
-                    'content': 'Return only valid JSON in natural Korean. No markdown.',
+                    'content': (
+                        'Return only valid JSON in natural Korean honorific speech. '
+                        'Use consistent 존댓말 only. No markdown.'
+                    ),
                 },
                 {
                     'role': 'user',
@@ -817,6 +821,9 @@ def normalize_comparison_feedback(payload: dict, fallback_feedback: dict):
             return fallback_feedback, f'missing_{field}'
         cleaned[field] = value[:max_length]
 
+    if not all(uses_consistent_polite_tone(value) for value in cleaned.values()):
+        return fallback_feedback, 'non_polite_tone'
+
     return cleaned, 'ai'
 
 
@@ -869,12 +876,15 @@ Delta
 
 Rules
 1. Write natural Korean without markdown.
-2. Focus on change from previous to current, not a generic profile review.
-3. growth must describe what improved or became clearer.
-4. needs_attention must describe what still looks weak or what declined.
-5. next_step must suggest one concrete action for the next saved record.
-6. Keep each field to one or two sentences.
-7. Do not mention raw JSON, prompts, or model limitations.
+2. Every field must use consistent polite Korean honorific speech only.
+3. Do not use casual speech, banmal, or plain "-다" narrative endings.
+4. End sentences politely, for example with forms like "~습니다", "~보입니다", or "~해보세요".
+5. Focus on change from previous to current, not a generic profile review.
+6. growth must describe what improved or became clearer.
+7. needs_attention must describe what still looks weak or what declined.
+8. next_step must suggest one concrete action for the next saved record.
+9. Keep each field to one or two sentences.
+10. Do not mention raw JSON, prompts, or model limitations.
 """.strip()
 
 
@@ -891,7 +901,10 @@ def generate_comparison_feedback_with_groq(summary: dict):
             messages=[
                 {
                     'role': 'system',
-                    'content': 'Return only valid JSON in natural Korean. No markdown.',
+                    'content': (
+                        'Return only valid JSON in natural Korean honorific speech. '
+                        'Use consistent 존댓말 only. No markdown.'
+                    ),
                 },
                 {
                     'role': 'user',

--- a/frontend/public/ads.txt
+++ b/frontend/public/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-6215904837522556, DIRECT, f08c47fec0942fa0

--- a/frontend/public/github-activity-interpretation.html
+++ b/frontend/public/github-activity-interpretation.html
@@ -7,6 +7,11 @@
       name="description"
       content="활동량, 꾸준함, 협업 흔적을 어떤 맥락으로 봐야 하는지 정리한 GitHub 활동 기록 해석 가이드입니다."
     />
+    <script
+      async
+      src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6215904837522556"
+      crossorigin="anonymous"
+    ></script>
     <title>GitHub 활동 기록 해석법 | Git Insight</title>
     <link rel="stylesheet" href="/static-page.css" />
     <style>

--- a/frontend/public/github-portfolio-guide.html
+++ b/frontend/public/github-portfolio-guide.html
@@ -7,6 +7,11 @@
       name="description"
       content="좋은 GitHub 포트폴리오를 만들기 위해 공개 저장소 구성, README, 활동 흐름을 어떻게 정리하면 좋은지 설명합니다."
     />
+    <script
+      async
+      src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6215904837522556"
+      crossorigin="anonymous"
+    ></script>
     <title>좋은 GitHub 포트폴리오 만드는 법 | Git Insight</title>
     <link rel="stylesheet" href="/static-page.css" />
     <style>

--- a/frontend/public/guide.html
+++ b/frontend/public/guide.html
@@ -7,6 +7,11 @@
       name="description"
       content="Git Insight 지표 해석 가이드. 이벤트 수, Push, 활동 일수, 언어 분포를 어떻게 읽으면 좋은지 설명합니다."
     />
+    <script
+      async
+      src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6215904837522556"
+      crossorigin="anonymous"
+    ></script>
     <title>지표 해석 가이드 | Git Insight</title>
     <link rel="stylesheet" href="/static-page.css" />
     <style>

--- a/frontend/public/readme-writing-guide.html
+++ b/frontend/public/readme-writing-guide.html
@@ -7,6 +7,11 @@
       name="description"
       content="프로젝트 목적, 주요 기능, 기술 선택 이유, 실행 방법을 어떻게 문서화하면 좋은지 정리한 README 작성 가이드입니다."
     />
+    <script
+      async
+      src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6215904837522556"
+      crossorigin="anonymous"
+    ></script>
     <title>README 잘 쓰는 법 | Git Insight</title>
     <link rel="stylesheet" href="/static-page.css" />
     <style>

--- a/frontend/src/components/LandingPage.jsx
+++ b/frontend/src/components/LandingPage.jsx
@@ -110,13 +110,13 @@ export function LandingPage({
             자주 묻는 질문
           </button>
           <button type="button" className="footer-link-button" onClick={() => onOpenPolicy('privacy')}>
-            개인정보 안내
+            개인정보처리방침
           </button>
           <button type="button" className="footer-link-button" onClick={() => onOpenPolicy('terms')}>
-            이용 안내
+            이용약관
           </button>
           <a href={feedbackFormUrl} target="_blank" rel="noreferrer">
-            문의/오류 제보
+            문의 및 오류 제보
           </a>
         </nav>
         <p>© 2026 Git Insight. All Rights Reserved.</p>

--- a/frontend/src/constants/appContent.js
+++ b/frontend/src/constants/appContent.js
@@ -57,7 +57,7 @@ export const POLICY_MODAL_CONTENT = {
     ],
   },
   privacy: {
-    title: '개인정보 처리 안내',
+    title: '개인정보처리방침',
     sections: [
       {
         heading: '어떤 정보를 다루나요?',
@@ -70,7 +70,7 @@ export const POLICY_MODAL_CONTENT = {
     ],
   },
   terms: {
-    title: '이용 안내',
+    title: '이용약관',
     sections: [
       {
         heading: '서비스 성격',
@@ -106,19 +106,19 @@ export const LANDING_CONTENT_SECTIONS = [
   {
     kicker: 'Why It Matters',
     title: 'GitHub 활동 분석이 중요한 이유',
-    summary: '포트폴리오나 공개 프로필에서 결과물뿐 아니라 과정과 리듬도 함께 읽히는 시대입니다.',
+    summary: '포트폴리오와 공개 프로필에서는 결과물뿐 아니라 작업 과정과 활동 흐름도 함께 읽히는 시대입니다.',
     points: [
-      '최근 활동의 흐름과 간격을 빠르게 읽을 수 있습니다.',
-      '채용, 협업, 포트폴리오 검토에서 공개 기록을 설명하기 쉬워집니다.',
+      '최근 활동의 흐름과 간격을 빠르게 파악할 수 있습니다.',
+      '채용, 협업, 포트폴리오 검토 상황에서 공개 기록을 더 쉽게 설명할 수 있습니다.',
     ],
     tags: ['공개 기록', '포트폴리오'],
   },
   {
     kicker: 'What We Read',
     title: '이 서비스가 읽는 데이터',
-    summary: '공개 레포, 저장소 언어, 이벤트 기록을 기반으로 최근 흐름을 기간별로 다시 정리합니다.',
+    summary: '공개 저장소, 사용 언어, 이벤트 기록을 바탕으로 최근 활동 흐름을 기간별로 다시 정리합니다.',
     points: [
-      '공개 프로필과 저장소, 이벤트를 기준으로 현재 흐름을 요약합니다.',
+      '공개 프로필, 저장소, 이벤트를 기준으로 현재 활동 흐름을 요약합니다.',
       '비공개 저장소와 조직 내부 작업은 충분히 반영되지 않을 수 있습니다.',
     ],
     tags: ['공개 데이터', '이벤트'],
@@ -134,16 +134,16 @@ export const CONTENT_LINKS = [
   {
     href: '/github-portfolio-guide.html',
     title: '좋은 GitHub 포트폴리오 만드는 법',
-    description: '공개 사용자 정보, README, 활동 흐름을 어떻게 정리하면 더 설득력 있게 보이는지 설명합니다.',
+    description: '공개 프로필, README, 활동 흐름을 어떻게 정리하면 더 설득력 있게 보이는지 설명하는 페이지입니다.',
   },
   {
     href: '/readme-writing-guide.html',
     title: 'README 작성 가이드',
-    description: '프로젝트 목적, 주요 기능, 실행 방법, 기술 선택 배경을 문서화하는 방법을 안내합니다.',
+    description: '프로젝트 목적, 주요 기능, 실행 방법, 기술 선택 배경을 어떻게 문서화하면 좋은지 안내하는 페이지입니다.',
   },
   {
     href: '/github-activity-interpretation.html',
     title: 'GitHub 활동 기록 해석법',
-    description: '활동량과 기록 패턴이 어떤 의미로 읽히는지 차분하게 풀어 설명합니다.',
+    description: '활동량과 기록 패턴이 어떤 의미로 읽히는지 차분하게 풀어 설명한 페이지입니다.',
   },
 ]


### PR DESCRIPTION
## 변경 내용
- AI 피드백과 비교 피드백의 말투를 일관된 존댓말로 고정했습니다.
- 말투가 어긋난 응답은 규칙 기반 문구로 fallback 하도록 검증을 보강했습니다.
- 읽을거리 성격의 정적 가이드 페이지 head 구성을 정리했습니다.
- 랜딩 소개 문구와 하단 안내 링크 표현을 더 자연스럽고 일관되게 다듬었습니다.

## 상세
- 일반 피드백/비교 피드백 프롬프트에 존댓말 규칙을 추가했습니다.
- 피드백 응답 정규화 단계에서 반말/비일관 말투를 걸러내도록 했습니다.
- 읽을거리 페이지 4곳의 head 구성을 정리했습니다.
- `공개 레포` 등 일부 표현을 `공개 저장소`처럼 더 자연스러운 용어로 통일했습니다.
- 하단 링크 문구를 `개인정보처리방침`, `이용약관`, `문의 및 오류 제보`로 정리했습니다.

## 확인
- `python -m compileall backend`
- 랜딩 문구 및 정적 페이지 변경 사항 확인

더 짧게 가려면:

## 변경 내용
- AI 피드백 말투를 존댓말로 일관되게 정리
- 비교 피드백 fallback 검증 강화
- 읽을거리 페이지 head 구성 정리
- 랜딩 문구와 안내 링크 표현 정리

## 확인
- `python -m compileall backend`
