### PR TITLE
chore: 피드백 톤과 랜딩/정적 페이지 구성을 정리

### DIFF
--- a/backend/tests/test_comparison_feedback.py
+++ b/backend/tests/test_comparison_feedback.py
@@ -1,0 +1,92 @@
+import sys
+import unittest
+from pathlib import Path
+
+
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+from feedback_utils import uses_consistent_polite_tone
+from main import build_comparison_feedback, normalize_comparison_feedback
+
+
+def make_summary():
+    return {
+        'username': 'octocat',
+        'window_days': 30,
+        'window_label': '최근 30일',
+        'current_generated_at': '2026-04-10T00:00:00Z',
+        'previous_generated_at': '2026-04-09T00:00:00Z',
+        'reliability_note': '',
+        'gained_languages': [],
+        'lost_languages': [],
+        'current': {
+            'total_events': 24,
+            'push_events': 10,
+            'active_days': 8,
+            'pull_request_events': 2,
+            'issue_events': 1,
+            'total_repos': 5,
+            'top_language': 'Python',
+            'language_count': 3,
+        },
+        'previous': {
+            'total_events': 20,
+            'push_events': 7,
+            'active_days': 6,
+            'pull_request_events': 1,
+            'issue_events': 0,
+            'total_repos': 4,
+            'top_language': 'Python',
+            'language_count': 2,
+        },
+        'delta': {
+            'total_events': 4,
+            'push_events': 3,
+            'active_days': 2,
+            'pull_request_events': 1,
+            'issue_events': 1,
+            'total_repos': 1,
+            'language_count': 1,
+        },
+    }
+
+
+class ComparisonFeedbackTests(unittest.TestCase):
+    def test_build_comparison_feedback_uses_polite_tone(self):
+        feedback = build_comparison_feedback(make_summary())
+
+        self.assertTrue(all(uses_consistent_polite_tone(value) for value in feedback.values()))
+
+    def test_normalize_comparison_feedback_accepts_polite_payload(self):
+        payload = {
+            'headline': '최근 30일 기준 직전 기록보다 활동 리듬이 더 안정적으로 보입니다.',
+            'growth': 'Push 기록과 활동 일수가 함께 늘어 작업 흐름이 더 또렷하게 읽힙니다.',
+            'needs_attention': 'PR 설명은 아직 적어 변경 이유와 협업 맥락은 더 보강할 여지가 있습니다.',
+            'next_step': '다음 기록에서는 PR 설명을 함께 남겨 변화 이유를 더 선명하게 보여주세요.',
+        }
+        fallback_feedback = build_comparison_feedback(make_summary())
+
+        normalized, reason = normalize_comparison_feedback(payload, fallback_feedback)
+
+        self.assertEqual(reason, 'ai')
+        self.assertEqual(normalized, payload)
+
+    def test_normalize_comparison_feedback_falls_back_for_non_polite_payload(self):
+        payload = {
+            'headline': '최근 30일 기준 직전 기록보다 활동 리듬이 더 안정적으로 보인다.',
+            'growth': 'Push 기록과 활동 일수가 함께 늘어 작업 흐름이 더 또렷하게 읽힌다.',
+            'needs_attention': 'PR 설명은 아직 적어 변경 이유와 협업 맥락은 더 보강할 여지가 있다.',
+            'next_step': '다음 기록에서는 PR 설명을 함께 남겨 변화 이유를 더 선명하게 보여주자.',
+        }
+        fallback_feedback = build_comparison_feedback(make_summary())
+
+        normalized, reason = normalize_comparison_feedback(payload, fallback_feedback)
+
+        self.assertEqual(reason, 'non_polite_tone')
+        self.assertEqual(normalized, fallback_feedback)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/backend/tests/test_feedback_utils.py
+++ b/backend/tests/test_feedback_utils.py
@@ -1,0 +1,75 @@
+import sys
+import unittest
+from pathlib import Path
+
+
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+from feedback_utils import normalize_feedback, sanitize_feedback, uses_consistent_polite_tone
+
+
+class FeedbackToneTests(unittest.TestCase):
+    def test_polite_tone_helper_accepts_consistent_honorifics(self):
+        self.assertTrue(
+            uses_consistent_polite_tone(
+                '최근 활동 흐름이 안정적으로 보입니다. 다음 기록도 기대됩니다.',
+            )
+        )
+
+    def test_polite_tone_helper_rejects_banmal(self):
+        self.assertFalse(
+            uses_consistent_polite_tone(
+                '최근 활동 흐름이 안정적으로 보여. 다음 기록도 기대된다.',
+            )
+        )
+
+    def test_sanitize_feedback_accepts_polite_payload(self):
+        payload = {
+            'headline': '최근 30일 활동 흐름이 또렷하게 이어지고 있습니다.',
+            'strength': 'Push 기록과 활동 일수가 함께 보여 작업 리듬이 비교적 안정적으로 읽힙니다.',
+            'improvement': 'PR 설명이 적어 변경 이유와 협업 맥락이 충분히 드러나지는 않습니다.',
+            'next_step': '다음 기록에서는 작은 수정이라도 PR 설명을 함께 남겨보세요.',
+        }
+
+        cleaned, reason = sanitize_feedback(payload)
+
+        self.assertEqual(reason, 'ok')
+        self.assertEqual(cleaned, payload)
+
+    def test_sanitize_feedback_rejects_non_polite_payload(self):
+        payload = {
+            'headline': '최근 30일 활동 흐름이 또렷하게 이어지고 있다.',
+            'strength': 'Push 기록과 활동 일수가 함께 보여 작업 리듬이 비교적 안정적으로 읽힌다.',
+            'improvement': 'PR 설명이 적어 변경 이유와 협업 맥락이 충분히 드러나지 않는다.',
+            'next_step': '다음 기록에서는 작은 수정이라도 PR 설명을 함께 남겨보자.',
+        }
+
+        cleaned, reason = sanitize_feedback(payload)
+
+        self.assertIsNone(cleaned)
+        self.assertEqual(reason, 'non_polite_tone')
+
+    def test_normalize_feedback_falls_back_for_non_polite_payload(self):
+        fallback_feedback = {
+            'headline': '기본 headline 입니다.',
+            'strength': '기본 strength 문장입니다.',
+            'improvement': '기본 improvement 문장입니다.',
+            'next_step': '기본 next_step 문장입니다.',
+        }
+        payload = {
+            'headline': '최근 활동 흐름이 이전보다 또렷하게 보인다.',
+            'strength': 'Push 기록이 꾸준히 보여 작업 흔적과 개발 리듬이 분명하게 읽힌다.',
+            'improvement': 'PR 설명이 부족해 변경 이유와 협업 맥락이 충분하게 드러나지 않는다.',
+            'next_step': '다음에는 작은 변경이라도 설명을 함께 남겨 흐름을 더 명확하게 보여주자.',
+        }
+
+        normalized, reason = normalize_feedback(payload, fallback_feedback)
+
+        self.assertEqual(normalized, fallback_feedback)
+        self.assertEqual(reason, 'non_polite_tone')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/frontend/src/styles/landing.css
+++ b/frontend/src/styles/landing.css
@@ -1,6 +1,9 @@
 .landing-shell {
   width: min(1280px, calc(100% - 40px));
+  min-height: 100vh;
   padding-top: 28px;
+  display: flex;
+  flex-direction: column;
 }
 
 .mypage-shell {
@@ -623,7 +626,8 @@
 
 .landing-footer {
   width: min(760px, 100%);
-  margin: 48px auto 0;
+  margin: auto auto 0;
+  padding-top: 48px;
   display: grid;
   justify-items: center;
   gap: 16px;

--- a/scripts/check_public_pages.py
+++ b/scripts/check_public_pages.py
@@ -1,0 +1,69 @@
+from pathlib import Path
+import sys
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+FRONTEND_DIR = ROOT_DIR / 'frontend'
+PUBLIC_DIR = FRONTEND_DIR / 'public'
+ADSENSE_MARKER = 'ca-pub-6215904837522556'
+ADS_TXT_CONTENT = 'google.com, pub-6215904837522556, DIRECT, f08c47fec0942fa0'
+
+REQUIRED_STATIC_PAGES = (
+    'guide.html',
+    'github-portfolio-guide.html',
+    'readme-writing-guide.html',
+    'github-activity-interpretation.html',
+)
+
+EXCLUDED_STATIC_PAGES = (
+    'about.html',
+    'faq.html',
+    'privacy.html',
+    'terms.html',
+    'commit-message-guide.html',
+    'pr-description-guide.html',
+)
+
+
+def assert_contains(path: Path, needle: str, label: str, errors: list[str]):
+    content = path.read_text(encoding='utf-8')
+    if needle not in content:
+        errors.append(f'{label}: expected marker was not found in {path.relative_to(ROOT_DIR)}')
+
+
+def assert_not_contains(path: Path, needle: str, label: str, errors: list[str]):
+    content = path.read_text(encoding='utf-8')
+    if needle in content:
+        errors.append(f'{label}: unexpected marker was found in {path.relative_to(ROOT_DIR)}')
+
+
+def main():
+    errors: list[str] = []
+
+    ads_path = PUBLIC_DIR / 'ads.txt'
+    if not ads_path.exists():
+        errors.append('ads.txt: frontend/public/ads.txt file is missing')
+    else:
+        ads_content = ads_path.read_text(encoding='utf-8').strip()
+        if ads_content != ADS_TXT_CONTENT:
+            errors.append('ads.txt: content does not match the expected publisher line')
+
+    assert_contains(FRONTEND_DIR / 'index.html', ADSENSE_MARKER, 'index.html', errors)
+
+    for filename in REQUIRED_STATIC_PAGES:
+        assert_contains(PUBLIC_DIR / filename, ADSENSE_MARKER, filename, errors)
+
+    for filename in EXCLUDED_STATIC_PAGES:
+        assert_not_contains(PUBLIC_DIR / filename, ADSENSE_MARKER, filename, errors)
+
+    if errors:
+        for error in errors:
+            print(error)
+        return 1
+
+    print('Public page checks passed.')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
## 변경 내용
- AI 피드백과 비교 피드백의 말투를 일관된 존댓말로 고정했습니다.
- 말투가 어긋난 응답은 규칙 기반 문구로 fallback 하도록 검증을 보강했습니다.
- `ads.txt`를 추가하고 읽을거리 성격의 정적 페이지 head 구성을 정리했습니다.
- 랜딩 문구, 푸터 표현, 푸터 하단 정렬을 함께 정리했습니다.
- 피드백 검증 테스트와 배포 점검 스크립트를 추가했습니다.

## 상세
- 일반 피드백/비교 피드백 프롬프트에 존댓말 규칙을 추가했습니다.
- 피드백 응답 정규화 단계에서 반말이나 비일관 말투를 걸러내도록 했습니다.
- `frontend/public/ads.txt`를 추가했습니다.
- 읽을거리 페이지 4곳의 head 구성을 정리했습니다.
- 랜딩 소개 문구와 푸터 링크 표현을 더 자연스럽고 일관되게 다듬었습니다.
- 랜딩 페이지에서 푸터가 화면 하단에 안정적으로 배치되도록 레이아웃을 조정했습니다.
- 백엔드 피드백 검증 테스트와 정적 페이지 구성 점검 스크립트를 추가했습니다.

## 확인
- `python -m compileall backend`
- `python -m unittest discover backend/tests`
- `python scripts/check_public_pages.py`

조금 더 짧게 가려면 이 버전도 괜찮습니다.

## 변경 내용
- AI 피드백 말투를 존댓말로 일관되게 정리
- 비교 피드백 fallback 검증 강화
- `ads.txt` 및 읽을거리 페이지 head 구성 정리
- 랜딩 문구, 푸터 표현, 푸터 하단 정렬 정리
- 피드백 테스트와 배포 점검 스크립트 추가

## 확인
- `python -m compileall backend`
- `python -m unittest discover backend/tests`
- `python scripts/check_public_pages.py`
